### PR TITLE
Add Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.retry
 node_modules/
 dist/
+/.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,12 @@ Vagrant.configure(2) do |config|
     config.vm.box = "fedora/25-cloud-base"
     config.vm.network "forwarded_port", guest: 9090, host: 9090
 
+    if Dir.glob("dist/*").length == 0
+      config.vm.post_up_message = "NOTE: Distribution directory is empty. Run `make` to see your module show up in cockpit"
+    end
+
     config.vm.synced_folder ".", "/vagrant", disabled: true
-    config.vm.synced_folder "dist/", "/usr/local/share/cockpit/" + File.basename(Dir.pwd)
+    config.vm.synced_folder "dist/", "/usr/local/share/cockpit/" + File.basename(Dir.pwd), create: true
 
     config.vm.provider "libvirt" do |libvirt|
         libvirt.memory = 1024

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,26 @@
+Vagrant.configure(2) do |config|
+    config.vm.box = "fedora/25-cloud-base"
+    config.vm.network "forwarded_port", guest: 9090, host: 9090
+
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+    config.vm.synced_folder "dist/", "/usr/local/share/cockpit/" + File.basename(Dir.pwd)
+
+    config.vm.provider "libvirt" do |libvirt|
+        libvirt.memory = 1024
+    end
+
+    config.vm.provider "virtualbox" do |virtualbox|
+        virtualbox.memory = 1024
+    end
+
+    config.vm.provision "shell", inline: <<-EOF
+        set -eu
+
+        sudo dnf install -y cockpit
+
+        printf "[WebService]\nAllowUnencrypted=true\n" > /etc/cockpit/cockpit.conf
+
+        systemctl enable cockpit.socket
+        systemctl start cockpit.socket
+    EOF
+end

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "version": "0.1",
     "requires": {
-        "cockpit": "138"
+        "cockpit": "137"
     },
 
     "tools": {


### PR DESCRIPTION
A simple Vagrant VM based on fedora 25 cloud. It syncs `dist` to
`/usr/local/share/cockpit/<dirname>` on the VM.

Also decrease the minimum required version in `manifest.json` to match
the one that's currently in fedora 25.